### PR TITLE
add quest link identity description

### DIFF
--- a/modules/apps/quest-preview.mjs
+++ b/modules/apps/quest-preview.mjs
@@ -52,6 +52,7 @@ export default class QuestPreview extends FormApplication {
       let entry = game.journal.get(this.quest.id);
       data.users = game.users;
       data.observerLevel = CONST.ENTITY_PERMISSIONS.OBSERVER;
+      data.questId = this.quest.id;
 
       data.users = game.users.map(u => {
         if (u.isGM) return;

--- a/styles/init.css
+++ b/styles/init.css
@@ -320,6 +320,11 @@
       gap: 1px 1px; }
       #forien-quest-preview .quest-body .management.active {
         display: grid; }
+      #forien-quest-preview .quest-body .management .part.info {
+        grid-column: span 2;
+        grid-row-start: 2; }
+      #forien-quest-preview .quest-body .management .part.info .identity code {
+        user-select: text; }
       #forien-quest-preview .quest-body .management .part.personal-quest .quest-is-personal {
         display: grid;
         grid-template-columns: auto 1fr;

--- a/styles/quest-preview.scss
+++ b/styles/quest-preview.scss
@@ -261,6 +261,16 @@
       }
 
       .part {
+        &.info {
+          grid-column: span 2;
+          grid-row-start: 2;
+
+          .identity code {
+            display: none;
+            user-select: text;
+          }
+        }
+
         &.personal-quest {
           .quest-is-personal {
             display: grid;

--- a/templates/partials/quest-preview/management.html
+++ b/templates/partials/quest-preview/management.html
@@ -11,3 +11,10 @@
     {{/each}}
     </div>
 </section>
+<section class="part info">
+    <div class="identity">
+        <p>
+            <small>You can use the following text to create a link to this quest: <code>@Quest[{{ questId }}]</code></small>
+        </p>
+    </div>
+</section>


### PR DESCRIPTION
Related to #41 

Added the id of the quest to the Manage Quest tab.

![image](https://user-images.githubusercontent.com/293277/85541855-d29cec00-b65b-11ea-85a4-020c5d35a260.png)

You'll likely need to do a proper rebuild of the CSS and adjust as you see fit. I just jammed it in there.