### PR TITLE
Fix Foundry VTT v14 compatibility

### DIFF
--- a/module.json
+++ b/module.json
@@ -19,8 +19,8 @@
   "version": "0.9.0",
   "compatibility": {
     "minimum": "13",
-    "verified": "13",
-    "maximum": "13"
+    "verified": "14",
+    "maximum": "14"
   },
   "esmodules": [
     "./src/init.js"

--- a/src/control/FQLHooks.js
+++ b/src/control/FQLHooks.js
@@ -217,7 +217,7 @@ export class FQLHooks
    {
       if (game.user.isGM || !game.settings.get(constants.moduleName, settings.hideFQLFromPlayers))
       {
-         controls.notes.tools = foundry.utils.mergeObject(controls.notes.tools, FoundryUIManager.noteControls);
+         Utils.addNoteControls(controls);
       }
    }
 
@@ -462,6 +462,51 @@ export class FQLHooks
    }
 
    /**
+    * Normalizes a render hook HTML argument to a root HTMLElement.
+    *
+    * @param {HTMLElement|JQuery|ArrayLike<HTMLElement>} html - Hook HTML argument.
+    *
+    * @returns {HTMLElement|null} Root element.
+    */
+   static getHookRoot(html)
+   {
+      if (!html) { return null; }
+
+      if (typeof html.querySelector === 'function') { return html; }
+
+      if (typeof html.get === 'function') { return html.get(0) ?? null; }
+
+      return html[0] ?? null;
+   }
+
+   /**
+    * Finds matching elements from a render hook HTML argument.
+    *
+    * @param {HTMLElement|JQuery|ArrayLike<HTMLElement>} html - Hook HTML argument.
+    *
+    * @param {string}                                    selector - CSS selector.
+    *
+    * @returns {HTMLElement[]} Matching elements.
+    */
+   static findHookElements(html, selector)
+   {
+      if (!html || typeof selector !== 'string') { return []; }
+
+      if (typeof html.find === 'function')
+      {
+         const result = html.find(selector);
+
+         if (typeof result?.toArray === 'function') { return result.toArray(); }
+
+         return Array.from(result ?? []);
+      }
+
+      const root = FQLHooks.getHookRoot(html);
+
+      return root ? Array.from(root.querySelectorAll(selector)) : [];
+   }
+
+   /**
     * Handles adding the 'open quest log' button at the bottom of the journal directory. Always displayed for the GM,
     * but only displayed to players if FQL isn't hidden via module setting {@link FQLSettings.hideFQLFromPlayers}.
     *
@@ -475,18 +520,22 @@ export class FQLHooks
     */
    static renderJournalDirectory(app, html)
    {
+      const root = FQLHooks.getHookRoot(html);
+
+      if (!root) { return; }
+
       if (game.user.isGM || !game.settings.get(constants.moduleName, settings.hideFQLFromPlayers))
       {
          const button = document.createElement('button');
          button.classList.add("quest-log-btn");
          button.innerText = game.i18n.localize('ForienQuestLog.QuestLog.Title');
 
-         let footer = html.querySelector('.directory-footer');
-         if (footer.length === 0)
+         let footer = root.querySelector('.directory-footer');
+         if (!footer)
          {
             footer = document.createElement("footer");
             footer.classList.add("directory-footer");
-            html.append(footer);
+            root.append(footer);
          }
          footer.append(button);
 
@@ -498,8 +547,8 @@ export class FQLHooks
          const folder = Utils.getQuestFolder();
          if (folder !== void 0)
          {
-            const element = html.querySelector(`.folder[data-folder-id="${folder.id}"]`);
-            if (element !== void 0)
+            const element = root.querySelector(`.folder[data-folder-id="${folder.id}"]`);
+            if (element)
             {
                element.remove();
             }
@@ -522,9 +571,9 @@ export class FQLHooks
       const folder = Utils.getQuestFolder();
       if (folder)
       {
-         const option = html.find(`option[value="${folder.id}"]`);
+         const options = FQLHooks.findHookElements(html, `option[value="${folder.id}"]`);
 
-         if (option) { option.remove(); }
+         for (const option of options) { option.remove(); }
       }
    }
 

--- a/src/control/ModuleSettings.js
+++ b/src/control/ModuleSettings.js
@@ -248,11 +248,7 @@ export class ModuleSettings
                   ViewManager.closeAll({ questPreview: true, updateSetting: false });
 
                   const controls = ui?.controls?.controls;
-                  if (controls)
-                  {
-                     delete controls.notes.tools.quest_log;
-                     delete controls.notes.tools.quest_tracker;
-                  }
+                  if (controls) { Utils.removeNoteControls(controls); }
 
                   // Remove all quests from in-memory DB. This is required so that users can not retrieve quests
                   // from the QuestAPI or content links in Foundry resolve when FQL is hidden.
@@ -265,17 +261,14 @@ export class ModuleSettings
 
                   // Add back ui.controls
                   const controls = ui?.controls?.controls;
-                  if (controls)
-                  {
-                     controls.notes.tools = foundry.utils.mergeObject(controls.notes.tools, FoundryUIManager.noteControls);
-                  }
+                  if (controls) { Utils.addNoteControls(controls); }
                }
 
                ui?.controls?.render(true);
             }
 
             // Render the journal to show / hide open quest log button & folder.
-            game?.journal?.render();
+            Utils.renderJournalDirectory();
 
             // Close or open the quest tracker based on active quests (users w/ FQL hidden will have no quests in
             // QuestDB)
@@ -304,7 +297,7 @@ export class ModuleSettings
          config: true,
          default: false,
          type: Boolean,
-         onChange: () => game.journal.render()  // Render the journal to show / hide the quest folder.
+         onChange: () => Utils.renderJournalDirectory()  // Render the journal to show / hide the quest folder.
       });
 
 // Settings not displayed in the module settings ---------------------------------------------------------------------

--- a/src/control/util/Utils.js
+++ b/src/control/util/Utils.js
@@ -1,4 +1,5 @@
-import { FVTTCompat }   from './index.js';
+import { FVTTCompat }   from './FVTTCompat.js';
+import { FoundryUIManager } from '../ui/FoundryUIManager.js';
 
 import {
    constants,
@@ -25,6 +26,115 @@ export class Utils
     * @type {string}
     */
    static #questDirName = '_fql_quests';
+
+   /**
+    * Returns the journal folder collection across supported Foundry APIs.
+    *
+    * @returns {Folder[]} Journal folders.
+    */
+   static getJournalFolders()
+   {
+      const folders = game.journal?.folders ?? game.folders;
+
+      if (!folders) { return []; }
+
+      if (typeof folders.filter === 'function')
+      {
+         return folders.filter((folder) => folder?.type === 'JournalEntry');
+      }
+
+      if (Array.isArray(folders))
+      {
+         return folders.filter((folder) => folder?.type === 'JournalEntry');
+      }
+
+      const folderContents = Array.from(folders.contents ?? folders ?? []);
+
+      return folderContents.filter((folder) => folder?.type === 'JournalEntry');
+   }
+
+   /**
+    * Renders the journal sidebar directory across supported Foundry APIs.
+    */
+   static renderJournalDirectory()
+   {
+      const journalApp = ui?.journal ?? ui?.sidebar?.tabs?.journal ?? game?.journal;
+
+      journalApp?.render?.(true);
+   }
+
+   /**
+    * Returns the notes scene control across supported Foundry APIs.
+    *
+    * @param {object[]|object} controls - Scene controls.
+    *
+    * @returns {object|null} Notes control.
+    */
+   static getNotesControl(controls)
+   {
+      if (!controls) { return null; }
+
+      if (Array.isArray(controls))
+      {
+         return controls.find((control) => control?.name === 'notes') ?? null;
+      }
+
+      if (typeof controls.find === 'function' && !controls.notes)
+      {
+         return controls.find((control) => control?.name === 'notes') ?? null;
+      }
+
+      return controls.notes ?? null;
+   }
+
+   /**
+    * Adds FQL note controls across supported Foundry scene control APIs.
+    *
+    * @param {object[]|object} controls - Scene controls.
+    */
+   static addNoteControls(controls)
+   {
+      const notesControl = this.getNotesControl(controls);
+
+      if (!notesControl) { return; }
+
+      if (Array.isArray(notesControl.tools))
+      {
+         const existing = new Set(notesControl.tools.map((tool) => tool?.name));
+
+         for (const tool of Object.values(FoundryUIManager.noteControls))
+         {
+            if (!existing.has(tool.name)) { notesControl.tools.push(tool); }
+         }
+
+         return;
+      }
+
+      notesControl.tools = foundry.utils.mergeObject(notesControl.tools ?? {}, FoundryUIManager.noteControls);
+   }
+
+   /**
+    * Removes FQL note controls across supported Foundry scene control APIs.
+    *
+    * @param {object[]|object} controls - Scene controls.
+    */
+   static removeNoteControls(controls)
+   {
+      const notesControl = this.getNotesControl(controls);
+
+      if (!notesControl?.tools) { return; }
+
+      if (Array.isArray(notesControl.tools))
+      {
+         notesControl.tools = notesControl.tools.filter((tool) => tool?.name !== 'quest_log' && tool?.name !==
+          'quest_tracker');
+
+         return;
+      }
+
+      delete notesControl.tools.quest_log;
+      delete notesControl.tools.quest_tracker;
+   }
 
    /**
     * Uses `navigator.clipboard` if available then falls back to `document.execCommand('copy')` if available to copy
@@ -233,7 +343,7 @@ export class Utils
     */
    static getQuestFolder()
    {
-      return game.journal.folders.find((f) => f.name === this.#questDirName);
+      return this.getJournalFolders().find((folder) => folder.name === this.#questDirName);
    }
 
    /**
@@ -280,7 +390,7 @@ export class Utils
     */
    static async initializeQuestFolder()
    {
-      const folder = game.journal.folders.find((f) => f.name === this.#questDirName);
+      const folder = this.getQuestFolder();
       if (folder !== void 0) { return folder; }
 
       if (game.user.isGM)
@@ -288,7 +398,7 @@ export class Utils
          await Folder.create({ name: this.#questDirName, type: 'JournalEntry', parent: null });
       }
 
-      return game.journal.folders.find((f) => f.name === this.#questDirName);
+      return this.getQuestFolder();
    }
 
    /**
@@ -393,12 +503,12 @@ export class Utils
             if (document.sheet.rendered)
             {
                document.sheet.bringToTop();
-               return null;
+               return document.sheet.appId ?? document.sheet.id ?? null;
             }
             else
             {
                document.sheet.render(true, options);
-               return document.sheet.appId;
+               return document.sheet.appId ?? document.sheet.id ?? null;
             }
          }
       }

--- a/src/view/internal/FQLDialog.js
+++ b/src/view/internal/FQLDialog.js
@@ -188,7 +188,7 @@ export class FQLDialog
 /**
  * Provides the FQL dialog implementation.
  */
-class FQLDialogImpl extends foundry.appv1.api.Dialog
+class FQLDialogImpl extends Dialog
 {
    /**
     * Stores the options specific to the dialog

--- a/src/view/log/QuestLog.js
+++ b/src/view/log/QuestLog.js
@@ -30,7 +30,7 @@ import * as contextOptions from "../internal/context-options.js";
  * {@link JQuery} control callbacks are setup in {@link QuestLog.activateListeners} and are located in a separate static
  * control class {@link HandlerLog}.
  */
-export class QuestLog extends foundry.appv1.api.Application
+export class QuestLog extends Application
 {
    /**
     * @inheritDoc

--- a/src/view/preview/QuestPreview.js
+++ b/src/view/preview/QuestPreview.js
@@ -71,7 +71,7 @@ import {
  * @see HandlerDetails
  * @see HandlerManage
  */
-export class QuestPreview extends foundry.appv1.api.FormApplication
+export class QuestPreview extends FormApplication
 {
    /**
     * Stores the quest being displayed / edited.

--- a/src/view/tracker/QuestTracker.js
+++ b/src/view/tracker/QuestTracker.js
@@ -28,7 +28,7 @@ import * as contextOptions from "../internal/context-options.js";
  * used in the {@link Handlebars} template. In the future this may be cached in a similar way that {@link Quest} data
  * is cached for {@link QuestLog}.
  */
-export class QuestTracker extends foundry.appv1.api.Application
+export class QuestTracker extends Application
 {
    /**
     * Provides the default width for the QuestTracker if not defined.


### PR DESCRIPTION
## Summary
- update manifest compatibility metadata for Foundry v14
- normalize journal render hook HTML handling for v14
- add compatibility helpers for journal folder lookup, journal rerender, and note controls
- add a sheet id fallback when returning opened sheet references

## Testing
- loaded the module in Foundry VTT v14
- confirmed the Journal sidebar footer button appears
- confirmed clicking the button opens Quest Log
- confirmed ability to create/edit quests
- verified no new first-party Quest Log console error on the tested path

## Notes
- these are changes I made to update the module to work on my v14 install
- submitting in case you find them to be helpful